### PR TITLE
Add option to upload and/or paste prompt context and model selector

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "OntoPrompt",
-  "version": "0.2",
+  "version": "0.3",
   "description": "Converts natural language to SPARQL using OpenAI.",
   "permissions": ["storage", "scripting", "activeTab"],
   "host_permissions": ["https://yasgui.triply.cc/*"],

--- a/styles.css
+++ b/styles.css
@@ -7,7 +7,8 @@
   padding: 16px;
   border-radius: 8px;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.25);
-  max-width: 640px;
+  width: 640px;
+  max-width: calc(100vw - 60px);
   min-width: 540px;
   max-height: 520px;
   overflow-y: auto;
@@ -67,15 +68,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-}
-
-.nl-context-charcount {
-  font-size: 0.75rem;
-  color: #6b7280;
-}
-
-.nl-context-charcount.is-warning {
-  color: #b45309;
+  margin-bottom: 14px;
 }
 
 .nl-context-input {
@@ -118,6 +111,32 @@
 
 .nl-context-upload-btn:hover {
   background: #f1f5f9;
+}
+
+.nl-model-label {
+  display: block;
+  font-size: 0.85rem;
+  color: #374151;
+  margin: 6px 0 4px;
+}
+
+.nl-model-select {
+  width: 100%;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid #c9d1d9;
+  background: #ffffff;
+  font-size: 0.9rem;
+  color: #1f2937;
+  box-sizing: border-box;
+}
+
+.nl-model-select:focus {
+  outline: 2px solid #2563eb;
+}
+
+.nl-context-label {
+  margin-top: 12px;
 }
 
 .nl-button--secondary {


### PR DESCRIPTION
closes https://github.com/twhetzel/sparql-chrome-extension/issues/11 

- **Model Picker**: Added an OpenAI model dropdown (default `gpt-5-chat-latest`) that persists via `chrome.storage` and automatically migrates legacy selections.
- **Prompt Context Enhancements**: Introduced an optional context textarea with file upload support (txt/md/json/sparql/csv/tsv/ttl/rdf), 20K-character trimming, and status feedback.
- **Layout Polish**: Locked the panel width in both idle and post-results states, adjusted spacing around the dropdown and text areas, and ensured the control buttons no longer overlap the context section.